### PR TITLE
Fix/mobile display

### DIFF
--- a/inst/HaDeX/ui.R
+++ b/inst/HaDeX/ui.R
@@ -11,36 +11,49 @@ ui <- tagList(
     tags$script(type = "text/javascript", src = "ga.js"),
     tags$script(type = "text/javascript", src = "detect-element-resize.js")
   ),
-  navbarPage(
-    title = "HaDeX",
-    tab_start(),
-    tab_input(),
-    navbarMenu(
-      title = "Plots",
-      tab_woods(),
-      tab_butterfly(),
-      tab_butterfly_diff(),
-      tab_volcano(),
-      tab_chiclet(),
-      tab_chiclet_diff(),
-      tab_uptake(),
-      tab_diff_uptake()
-    ),
-    navbarMenu(
-      title = "Time-based data",
-      tab_replicates(),
-      tab_manhattan(),
-      tab_quality
-    ),
-    navbarMenu(
-      title = "Sequence data",
-      tab_sequence,
-      tab_coverage
-    ),
-    tab_summary(),
-    tab_report(),
-    
-    theme = "HaDeX_theme.css",
-    header = img(id = "HaDeX-logo", src = "logo.png")
+  div(
+    id = "fullsize-website",
+    navbarPage(
+      title = "HaDeX",
+      tab_start(),
+      tab_input(),
+      navbarMenu(
+        title = "Plots",
+        tab_woods(),
+        tab_butterfly(),
+        tab_butterfly_diff(),
+        tab_volcano(),
+        tab_chiclet(),
+        tab_chiclet_diff(),
+        tab_uptake(),
+        tab_diff_uptake()
+      ),
+      navbarMenu(
+        title = "Time-based data",
+        tab_replicates(),
+        tab_manhattan(),
+        tab_quality
+      ),
+      navbarMenu(
+        title = "Sequence data",
+        tab_sequence,
+        tab_coverage
+      ),
+      tab_summary(),
+      tab_report(),
+      
+      theme = "HaDeX_theme.css",
+      header = img(id = "HaDeX-logo", src = "logo.png")
+    )
+  ),
+  div(
+    id = "mobile-website",
+    navbarPage(
+      title = "HaDeX",
+      tab_start(mobile = TRUE),
+      
+      theme = "HaDeX_theme.css",
+      header = img(id = "HaDeX-logo", src = "logo.png")
+    )
   )
 )

--- a/inst/HaDeX/ui.R
+++ b/inst/HaDeX/ui.R
@@ -5,43 +5,42 @@ for (file in list.files("ui", full.names = TRUE)) source(file, local = TRUE)
 
 options(shiny.useragg = TRUE)
 
-ui <- tagList(useShinyjs(),
-              tags$head(includeScript("ga.js"),
-                        tags$script(type="text/javascript",
-                                    src="detect-element-resize.js")),
-                navbarPage(
-                  "HaDeX",
-                  tab_start(),
-                  tab_input(),
-                  navbarMenu(
-                    "Plots",
-                    tab_woods(),
-                    tab_butterfly(),
-                    tab_butterfly_diff(),
-                    tab_volcano(),
-                    tab_chiclet(),
-                    tab_chiclet_diff(),
-                    tab_uptake(),
-                    tab_diff_uptake()
-                  ),
-                  navbarMenu(
-                    "Time-based data",
-                    tab_replicates(),
-                    tab_manhattan(),
-                    tab_quality
-                  ),
-                  navbarMenu(
-                    "Sequence data",
-                    tab_sequence,
-                    tab_coverage
-                  ),
-                  tab_summary(),
-                  tab_report(),
-                  
-                  theme = "HaDeX_theme.css",
-                  header = img(
-                    id = "HaDeX-logo",
-                    src = "logo.png"
-                  )
-              )
+ui <- tagList(
+  useShinyjs(),
+  tags$head(
+    tags$script(type = "text/javascript", src = "ga.js"),
+    tags$script(type = "text/javascript", src = "detect-element-resize.js")
+  ),
+  navbarPage(
+    title = "HaDeX",
+    tab_start(),
+    tab_input(),
+    navbarMenu(
+      title = "Plots",
+      tab_woods(),
+      tab_butterfly(),
+      tab_butterfly_diff(),
+      tab_volcano(),
+      tab_chiclet(),
+      tab_chiclet_diff(),
+      tab_uptake(),
+      tab_diff_uptake()
+    ),
+    navbarMenu(
+      title = "Time-based data",
+      tab_replicates(),
+      tab_manhattan(),
+      tab_quality
+    ),
+    navbarMenu(
+      title = "Sequence data",
+      tab_sequence,
+      tab_coverage
+    ),
+    tab_summary(),
+    tab_report(),
+    
+    theme = "HaDeX_theme.css",
+    header = img(id = "HaDeX-logo", src = "logo.png")
+  )
 )

--- a/inst/HaDeX/ui/ui_tab_start.R
+++ b/inst/HaDeX/ui/ui_tab_start.R
@@ -1,6 +1,11 @@
-tab_start <- function() HaDeX_nonplotTab(
+tab_start <- function(mobile = FALSE) HaDeX_nonplotTab(
   title = "Start",
   h1("Welcome to HaDeX!"),
+  if (!mobile) NULL else p(
+    tags$b(
+      "For better user experience please use device with wider screen (at least 900px)."
+    )
+  ),
   p(
     "Thank you for using our tool.",
     "Questions/feature requests/commercial applications: hadex@ibb.waw.pl"

--- a/inst/HaDeX/www/HaDeX_theme.css
+++ b/inst/HaDeX/www/HaDeX_theme.css
@@ -369,3 +369,21 @@ h4, .h4 {
 .shiny-split-layout > div {
   overflow: visible;
 }
+
+#fullsize-website {
+  display: block;
+}
+
+#mobile-website {
+  display: none;
+}
+
+@media (max-width: 767px) {                  
+  #fullsize-website {
+    display: none;
+  }
+  
+  #mobile-website {
+    display: block;
+  }
+}


### PR DESCRIPTION
This PR is meant to solve #102 . It reintroduces the mobile version of the website (for devices with the width smaller than 900px). Instead of rendering all the other tabs, it shows information on the start page that bigger display is needed.

![Example of display on smaller device](https://user-images.githubusercontent.com/32573752/165506132-a8f38fe1-5863-4f53-9a03-76c17d31274c.png)

This soution is pretty rough, though, and probably can be optimized to be less redundant and more fancy.